### PR TITLE
Removing decorators from all node types that might have them

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+import babelPluginSyntaxDecorators from 'babel-plugin-syntax-decorators';
+
 const decoratableTypes = [
     "ArrayPattern",
     "AssignmentPattern",
@@ -14,6 +16,7 @@ const decoratableTypes = [
 
 export default function () {
     return {
+        inherits: babelPluginSyntaxDecorators,
         visitor: {
             [decoratableTypes.join('|')]: function (path) {
                 path.node.decorators = null

--- a/index.js
+++ b/index.js
@@ -1,7 +1,21 @@
+const decoratableTypes = [
+    "ArrayPattern",
+    "AssignmentPattern",
+    "ClassExpression",
+    "ClassDeclaration",
+    "ClassMethod",
+    "ClassProperty",
+    "Identifier",
+    "ObjectMethod",
+    "ObjectPattern",
+    "ObjectProperty",
+    "RestElement"
+];
+
 export default function () {
     return {
         visitor: {
-            ClassExpression: function (path) {
+            [decoratableTypes.join('|')]: function (path) {
                 path.node.decorators = null
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-remove-decorator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Babel 6 plugin that removes all decorators",
   "main": "built.js",
   "license": "MIT",
@@ -11,5 +11,8 @@
     "babel": "^6.5.2",
     "babel-cli": "^6.18.0",
     "babel-preset-es2015": "^6.18.0"
+  },
+  "dependencies": {
+    "babel-plugin-syntax-decorators": "^6.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-remove-decorator",
-  "version": "0.1.2",
-  "description": "Babel 6 plugin that removes class decorators",
+  "version": "0.2.0",
+  "description": "Babel 6 plugin that removes all decorators",
   "main": "built.js",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
I added all node types that, according to the [babel-types](https://github.com/babel/babel/tree/master/packages/babel-types) documentation, can have decorators on them. So in theory, the new code should remove all decorators everywhere.

I've tried it on some local examples, and I suggest you do the same before you merge. Unfortunately, I don't have time to set up a test framework.